### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ This project is actively developed thanks to the people who support it on [Boost
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SunOner/sunone_aimbot_2&type=date&legend=top-left)](https://www.star-history.com/#SunOner/sunone_aimbot_2&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=SunOner/sunone_aimbot_2&type=date&legend=top-left)](https://star-history.dera.page/#SunOner/sunone_aimbot_2&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This change points it to a working alternative service so the chart displays correctly again. No other changes are included.