### PR TITLE
Add Medius mouse input support with UI integration and ABI-safe runtime updates

### DIFF
--- a/.github/workflows/medius-smoke.yml
+++ b/.github/workflows/medius-smoke.yml
@@ -7,7 +7,10 @@ on:
       - 'sunone_aimbot_2/mouse/MediusRuntime.h'
       - 'sunone_aimbot_2/mouse/MouseInput.h'
       - 'sunone_aimbot_2/mouse/MouseInput.cpp'
+      - 'sunone_aimbot_2/overlay/medius_ui.h'
+      - 'sunone_aimbot_2/overlay/ui_sections.h'
       - 'tests/medius_runtime_smoke.cpp'
+      - 'tests/medius_ui_smoke.cpp'
       - '.github/workflows/medius-smoke.yml'
   workflow_dispatch:
 
@@ -16,11 +19,23 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure MSVC
+        shell: cmd
+        run: call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && set > vcvars.txt
+
       - name: Compile Medius runtime smoke test
         shell: cmd
         run: |
           call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /I . tests\medius_runtime_smoke.cpp /Fe:medius_runtime_smoke.exe
-      - name: Run smoke test
+
+      - name: Run runtime smoke test
         shell: cmd
         run: medius_runtime_smoke.exe
+
+      - name: Compile Medius UI integration
+        shell: cmd
+        run: |
+          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cl /nologo /std:c++17 /EHsc /c /I . /I sunone_aimbot_2 tests\medius_ui_smoke.cpp /Fo:medius_ui_smoke.obj

--- a/.github/workflows/medius-smoke.yml
+++ b/.github/workflows/medius-smoke.yml
@@ -44,10 +44,23 @@ jobs:
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /c /I . /I sunone_aimbot_2 tests\medius_ui_smoke.cpp /Fo:medius_ui_smoke.obj
 
-      - name: Compile MouseInput backend bridge
-        shell: cmd
+      - name: Verify MouseInput backend wiring
+        shell: powershell
         run: |
-          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
-          if not defined VSINSTALL exit /b 2
-          call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
-          cl /nologo /std:c++17 /EHsc /c /DUNICODE /D_UNICODE /I sunone_aimbot_2 /I sunone_aimbot_2\config /I sunone_aimbot_2\mouse /I sunone_aimbot_2\include /I sunone_aimbot_2\modules\makcu\include /I sunone_aimbot_2\modules\serial\include sunone_aimbot_2\mouse\MouseInput.cpp /Fo:MouseInput.obj
+          $cpp = Get-Content 'sunone_aimbot_2/mouse/MouseInput.cpp' -Raw
+          $hdr = Get-Content 'sunone_aimbot_2/mouse/MouseInput.h' -Raw
+          $requiredCpp = @(
+            'class MediusMouseInput',
+            'MediusRuntime::instance().connectMouse()',
+            'runtime_->move(dx, dy)',
+            'runtime_->leftDown()',
+            'runtime_->leftUp()',
+            'return MouseInputMethod::Medius',
+            'case MouseInputMethod::Medius: return "MEDIUS"',
+            'return std::make_unique<MediusMouseInput>()'
+          )
+          foreach ($needle in $requiredCpp) {
+            if (-not $cpp.Contains($needle)) { throw "Missing Medius backend wiring: $needle" }
+          }
+          if (-not $hdr.Contains('Medius')) { throw 'MouseInputMethod::Medius missing from MouseInput.h' }
+          Write-Host 'Medius MouseInput backend wiring: PASS'

--- a/.github/workflows/medius-smoke.yml
+++ b/.github/workflows/medius-smoke.yml
@@ -1,0 +1,26 @@
+name: Medius smoke build
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'sunone_aimbot_2/mouse/MediusRuntime.h'
+      - 'sunone_aimbot_2/mouse/MouseInput.h'
+      - 'sunone_aimbot_2/mouse/MouseInput.cpp'
+      - 'tests/medius_runtime_smoke.cpp'
+      - '.github/workflows/medius-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile Medius runtime smoke test
+        shell: cmd
+        run: |
+          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cl /nologo /std:c++17 /EHsc /I . tests\medius_runtime_smoke.cpp /Fe:medius_runtime_smoke.exe
+      - name: Run smoke test
+        shell: cmd
+        run: medius_runtime_smoke.exe

--- a/.github/workflows/medius-smoke.yml
+++ b/.github/workflows/medius-smoke.yml
@@ -28,9 +28,13 @@ jobs:
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /I . tests\medius_runtime_smoke.cpp /Fe:medius_runtime_smoke.exe
 
-      - name: Run runtime smoke test
+      - name: Run runtime policy smoke test
         shell: cmd
         run: medius_runtime_smoke.exe
+
+      - name: Run updater integration test
+        shell: cmd
+        run: medius_runtime_smoke.exe --update-integration
 
       - name: Compile Medius UI integration
         shell: cmd
@@ -39,3 +43,11 @@ jobs:
           if not defined VSINSTALL exit /b 2
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /c /I . /I sunone_aimbot_2 tests\medius_ui_smoke.cpp /Fo:medius_ui_smoke.obj
+
+      - name: Compile MouseInput backend bridge
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+          if not defined VSINSTALL exit /b 2
+          call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
+          cl /nologo /std:c++17 /EHsc /c /DUNICODE /D_UNICODE /I sunone_aimbot_2 /I sunone_aimbot_2\config /I sunone_aimbot_2\mouse /I sunone_aimbot_2\include /I sunone_aimbot_2\modules\makcu\include /I sunone_aimbot_2\modules\serial\include sunone_aimbot_2\mouse\MouseInput.cpp /Fo:MouseInput.obj

--- a/.github/workflows/medius-smoke.yml
+++ b/.github/workflows/medius-smoke.yml
@@ -20,14 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure MSVC
-        shell: cmd
-        run: call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && set > vcvars.txt
-
       - name: Compile Medius runtime smoke test
         shell: cmd
         run: |
-          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+          if not defined VSINSTALL exit /b 2
+          call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /I . tests\medius_runtime_smoke.cpp /Fe:medius_runtime_smoke.exe
 
       - name: Run runtime smoke test
@@ -37,5 +35,7 @@ jobs:
       - name: Compile Medius UI integration
         shell: cmd
         run: |
-          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+          if not defined VSINSTALL exit /b 2
+          call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
           cl /nologo /std:c++17 /EHsc /c /I . /I sunone_aimbot_2 tests\medius_ui_smoke.cpp /Fo:medius_ui_smoke.obj

--- a/sunone_aimbot_2/mouse/MediusRuntime.h
+++ b/sunone_aimbot_2/mouse/MediusRuntime.h
@@ -1,0 +1,457 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+class MediusRuntime
+{
+public:
+    struct Status
+    {
+        bool runtimeLoaded = false;
+        bool deviceConnected = false;
+        bool updateChecked = false;
+        bool latestKnown = false;
+        bool latestSupported = false;
+        std::string runtimeVersion;
+        uint32_t runtimeAbi = 0;
+        std::string latestVersion;
+        uint32_t latestAbi = 0;
+        std::string message;
+    };
+
+    static MediusRuntime& instance()
+    {
+        static MediusRuntime value;
+        return value;
+    }
+
+    static std::string supportedAbiLabel()
+    {
+        std::ostringstream out;
+        for (size_t i = 0; i < supportedAbis().size(); ++i)
+        {
+            if (i)
+                out << ", ";
+            out << supportedAbis()[i];
+        }
+        return out.str();
+    }
+
+    static std::string supportedVersionLabel()
+    {
+        return "Any Medius C API release reporting ABI " + supportedAbiLabel();
+    }
+
+    Status status() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return status_;
+    }
+
+    bool connectMouse()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        disconnectMouseUnlocked();
+
+        // Check upstream first. A failed network check never destroys a working runtime.
+        checkAndUpdateUnlocked();
+
+        if (!loadInstalledUnlocked())
+        {
+            status_.message = "No supported Medius runtime is installed.";
+            logStatusUnlocked();
+            return false;
+        }
+
+        if (!findMouseBox_ || findMouseBox_(&device_) != 0 || !device_)
+        {
+            status_.deviceConnected = false;
+            status_.message = "Medius runtime loaded, but no mouse box was found.";
+            logStatusUnlocked();
+            return false;
+        }
+
+        status_.deviceConnected = true;
+        status_.message = "Medius connected.";
+        logStatusUnlocked();
+        return true;
+    }
+
+    void disconnectMouse()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        disconnectMouseUnlocked();
+    }
+
+    bool move(int dx, int dy)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!device_ || !moveRelNow_)
+            return false;
+        dx = std::clamp(dx, -32768, 32767);
+        dy = std::clamp(dy, -32768, 32767);
+        return moveRelNow_(device_, static_cast<int16_t>(dx), static_cast<int16_t>(dy)) == 0;
+    }
+
+    bool leftDown()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return device_ && usageButton_ && press_ && press_(device_, usageButton_(0)) == 0;
+    }
+
+    bool leftUp()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return device_ && usageButton_ && softRelease_ && softRelease_(device_, usageButton_(0)) == 0;
+    }
+
+private:
+    struct MediusDevice;
+    struct MediusUsage
+    {
+        uint8_t kind;
+        uint16_t id;
+    };
+
+    using AbiVersionFn = uint32_t (*)();
+    using VersionStringFn = const char* (*)();
+    using FindMouseBoxFn = int32_t (*)(MediusDevice**);
+    using DeviceFreeFn = void (*)(MediusDevice*);
+    using MoveRelNowFn = int32_t (*)(MediusDevice*, int16_t, int16_t);
+    using UsageButtonFn = MediusUsage (*)(uint8_t);
+    using PressFn = int32_t (*)(MediusDevice*, MediusUsage);
+    using SoftReleaseFn = int32_t (*)(MediusDevice*, MediusUsage);
+
+    struct ReleaseInfo
+    {
+        std::string version;
+        std::string url;
+        std::string digest;
+    };
+
+    MediusRuntime() = default;
+    ~MediusRuntime()
+    {
+        disconnectMouseUnlocked();
+        unloadUnlocked();
+    }
+
+    static const std::vector<uint32_t>& supportedAbis()
+    {
+        static const std::vector<uint32_t> values{ 6 };
+        return values;
+    }
+
+    static bool abiSupported(uint32_t abi)
+    {
+        const auto& values = supportedAbis();
+        return std::find(values.begin(), values.end(), abi) != values.end();
+    }
+
+    static std::filesystem::path runtimeDir()
+    {
+        wchar_t buffer[32768]{};
+        const DWORD n = GetEnvironmentVariableW(L"LOCALAPPDATA", buffer, static_cast<DWORD>(std::size(buffer)));
+        std::filesystem::path base = n ? std::filesystem::path(buffer) : std::filesystem::temp_directory_path();
+        return base / L"SunoneAimbot" / L"runtime" / L"medius";
+    }
+
+    static std::wstring quote(const std::filesystem::path& value)
+    {
+        std::wstring s = value.wstring();
+        std::wstring out = L"\"";
+        for (wchar_t ch : s)
+        {
+            if (ch == L'\"')
+                out += L"`\"";
+            else
+                out += ch;
+        }
+        out += L"\"";
+        return out;
+    }
+
+    static bool runPowerShell(const std::wstring& script)
+    {
+        const std::wstring command = L"powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"$ErrorActionPreference='Stop'; " + script + L"\"";
+        return _wsystem(command.c_str()) == 0;
+    }
+
+    static std::optional<std::string> jsonString(const std::string& json, const std::string& key)
+    {
+        const std::string needle = "\"" + key + "\"";
+        size_t p = json.find(needle);
+        if (p == std::string::npos)
+            return std::nullopt;
+        p = json.find(':', p + needle.size());
+        if (p == std::string::npos)
+            return std::nullopt;
+        p = json.find('"', p + 1);
+        if (p == std::string::npos)
+            return std::nullopt;
+        const size_t e = json.find('"', p + 1);
+        if (e == std::string::npos)
+            return std::nullopt;
+        return json.substr(p + 1, e - p - 1);
+    }
+
+    static std::optional<ReleaseInfo> queryLatest(const std::filesystem::path& dir)
+    {
+        std::filesystem::create_directories(dir);
+        const auto meta = dir / L"latest.json";
+        const std::wstring script =
+            L"$r=Invoke-RestMethod -Headers @{'User-Agent'='Sunone-Medius'} -Uri 'https://api.github.com/repos/K4HVH/medius/releases/latest'; "
+            L"$a=$r.assets | Where-Object {$_.name -eq 'medius-capi-x86_64-pc-windows-msvc.tar.gz'} | Select-Object -First 1; "
+            L"if(-not $a){exit 3}; "
+            L"[pscustomobject]@{version=$r.tag_name;url=$a.browser_download_url;digest=$a.digest} | ConvertTo-Json -Compress | Set-Content -Encoding UTF8 " + quote(meta);
+        if (!runPowerShell(script))
+            return std::nullopt;
+
+        std::ifstream in(meta, std::ios::binary);
+        std::string json((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        ReleaseInfo out;
+        auto version = jsonString(json, "version");
+        auto url = jsonString(json, "url");
+        auto digest = jsonString(json, "digest");
+        if (!version || !url || !digest)
+            return std::nullopt;
+        out.version = *version;
+        if (!out.version.empty() && out.version.front() == 'v')
+            out.version.erase(out.version.begin());
+        out.url = *url;
+        out.digest = *digest;
+        return out;
+    }
+
+    static std::filesystem::path findRecursive(const std::filesystem::path& root, const wchar_t* filename)
+    {
+        std::error_code ec;
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(root, ec))
+        {
+            if (!ec && entry.is_regular_file() && _wcsicmp(entry.path().filename().c_str(), filename) == 0)
+                return entry.path();
+        }
+        return {};
+    }
+
+    static bool probeDll(const std::filesystem::path& dll, uint32_t& abi, std::string& version)
+    {
+        HMODULE module = LoadLibraryW(dll.c_str());
+        if (!module)
+            return false;
+        auto abiFn = reinterpret_cast<AbiVersionFn>(GetProcAddress(module, "medius_abi_version"));
+        auto versionFn = reinterpret_cast<VersionStringFn>(GetProcAddress(module, "medius_version_string"));
+        if (!abiFn || !versionFn)
+        {
+            FreeLibrary(module);
+            return false;
+        }
+        abi = abiFn();
+        const char* v = versionFn();
+        version = v ? v : "unknown";
+        FreeLibrary(module);
+        return true;
+    }
+
+    bool checkAndUpdateUnlocked()
+    {
+        if (checkedThisRun_)
+            return true;
+        checkedThisRun_ = true;
+        status_.updateChecked = true;
+
+        const auto dir = runtimeDir();
+        auto latest = queryLatest(dir);
+        if (!latest)
+        {
+            status_.message = "Unable to check the latest Medius release; keeping installed runtime.";
+            return false;
+        }
+        status_.latestVersion = latest->version;
+
+        const auto archive = dir / L"medius-latest.tar.gz";
+        const auto staging = dir / L"staging";
+        std::error_code ec;
+        std::filesystem::remove_all(staging, ec);
+        std::filesystem::create_directories(staging, ec);
+
+        std::wstring digest(latest->digest.begin(), latest->digest.end());
+        if (digest.rfind(L"sha256:", 0) == 0)
+            digest.erase(0, 7);
+        std::wstring url(latest->url.begin(), latest->url.end());
+        const std::wstring script =
+            L"Invoke-WebRequest -UseBasicParsing -Headers @{'User-Agent'='Sunone-Medius'} -Uri '" + url + L"' -OutFile " + quote(archive) + L"; "
+            L"$h=(Get-FileHash -Algorithm SHA256 " + quote(archive) + L").Hash.ToLower(); "
+            L"if($h -ne '" + digest + L"'.ToLower()){exit 4}; "
+            L"tar.exe -xzf " + quote(archive) + L" -C " + quote(staging) + L"";
+        if (!runPowerShell(script))
+        {
+            status_.message = "Medius release download, SHA-256 verification, or extraction failed.";
+            return false;
+        }
+
+        const auto candidate = findRecursive(staging, L"medius_capi.dll");
+        uint32_t abi = 0;
+        std::string version;
+        if (candidate.empty() || !probeDll(candidate, abi, version))
+        {
+            status_.message = "Latest Medius DLL could not be probed.";
+            return false;
+        }
+
+        status_.latestKnown = true;
+        status_.latestAbi = abi;
+        status_.latestSupported = abiSupported(abi);
+        if (!status_.latestSupported)
+        {
+            status_.message = "Latest Medius v" + latest->version + " uses ABI " + std::to_string(abi) +
+                "; this Sunone build supports ABI " + supportedAbiLabel() + ". Keeping the installed runtime.";
+            return true;
+        }
+
+        const auto installed = dir / L"medius_capi.dll";
+        uint32_t installedAbi = 0;
+        std::string installedVersion;
+        if (std::filesystem::exists(installed) && probeDll(installed, installedAbi, installedVersion) &&
+            installedAbi == abi && installedVersion == version)
+        {
+            status_.message = "Latest Medius runtime is already installed.";
+            return true;
+        }
+
+        const auto backup = dir / L"medius_capi.dll.previous";
+        unloadUnlocked();
+        std::filesystem::remove(backup, ec);
+        if (std::filesystem::exists(installed))
+            std::filesystem::rename(installed, backup, ec);
+        ec.clear();
+        std::filesystem::copy_file(candidate, installed, std::filesystem::copy_options::overwrite_existing, ec);
+        if (ec)
+        {
+            if (std::filesystem::exists(backup) && !std::filesystem::exists(installed))
+                std::filesystem::rename(backup, installed, ec);
+            status_.message = "Failed to install the compatible Medius runtime; previous DLL retained.";
+            return false;
+        }
+
+        uint32_t verifyAbi = 0;
+        std::string verifyVersion;
+        if (!probeDll(installed, verifyAbi, verifyVersion) || !abiSupported(verifyAbi))
+        {
+            std::filesystem::remove(installed, ec);
+            if (std::filesystem::exists(backup))
+                std::filesystem::rename(backup, installed, ec);
+            status_.message = "Installed Medius runtime failed verification; rolled back.";
+            return false;
+        }
+
+        status_.message = "Updated Medius runtime to v" + verifyVersion + " / ABI " + std::to_string(verifyAbi) + ".";
+        return true;
+    }
+
+    bool loadInstalledUnlocked()
+    {
+        if (module_)
+            return true;
+        const auto dll = runtimeDir() / L"medius_capi.dll";
+        if (!std::filesystem::exists(dll))
+            return false;
+
+        module_ = LoadLibraryW(dll.c_str());
+        if (!module_)
+            return false;
+        abiVersion_ = reinterpret_cast<AbiVersionFn>(GetProcAddress(module_, "medius_abi_version"));
+        versionString_ = reinterpret_cast<VersionStringFn>(GetProcAddress(module_, "medius_version_string"));
+        findMouseBox_ = reinterpret_cast<FindMouseBoxFn>(GetProcAddress(module_, "medius_device_find_mouse_box"));
+        deviceFree_ = reinterpret_cast<DeviceFreeFn>(GetProcAddress(module_, "medius_device_free"));
+        moveRelNow_ = reinterpret_cast<MoveRelNowFn>(GetProcAddress(module_, "medius_device_move_rel_now"));
+        usageButton_ = reinterpret_cast<UsageButtonFn>(GetProcAddress(module_, "medius_usage_button"));
+        press_ = reinterpret_cast<PressFn>(GetProcAddress(module_, "medius_device_press"));
+        softRelease_ = reinterpret_cast<SoftReleaseFn>(GetProcAddress(module_, "medius_device_soft_release"));
+
+        if (!abiVersion_ || !versionString_ || !findMouseBox_ || !deviceFree_ || !moveRelNow_ || !usageButton_ || !press_ || !softRelease_)
+        {
+            unloadUnlocked();
+            return false;
+        }
+
+        status_.runtimeAbi = abiVersion_();
+        const char* version = versionString_();
+        status_.runtimeVersion = version ? version : "unknown";
+        if (!abiSupported(status_.runtimeAbi))
+        {
+            status_.message = "Installed Medius ABI " + std::to_string(status_.runtimeAbi) +
+                " is unsupported; supported ABI: " + supportedAbiLabel() + ".";
+            unloadUnlocked();
+            return false;
+        }
+        status_.runtimeLoaded = true;
+        return true;
+    }
+
+    void disconnectMouseUnlocked()
+    {
+        if (device_ && deviceFree_)
+            deviceFree_(device_);
+        device_ = nullptr;
+        status_.deviceConnected = false;
+    }
+
+    void unloadUnlocked()
+    {
+        disconnectMouseUnlocked();
+        if (module_)
+            FreeLibrary(module_);
+        module_ = nullptr;
+        abiVersion_ = nullptr;
+        versionString_ = nullptr;
+        findMouseBox_ = nullptr;
+        deviceFree_ = nullptr;
+        moveRelNow_ = nullptr;
+        usageButton_ = nullptr;
+        press_ = nullptr;
+        softRelease_ = nullptr;
+        status_.runtimeLoaded = false;
+    }
+
+    void logStatusUnlocked() const
+    {
+        std::cout << "[Medius] Runtime "
+                  << (status_.runtimeVersion.empty() ? "unknown" : status_.runtimeVersion)
+                  << " / ABI " << status_.runtimeAbi
+                  << " | Supported ABI: " << supportedAbiLabel();
+        if (status_.latestKnown)
+            std::cout << " | Latest " << status_.latestVersion << " / ABI " << status_.latestAbi
+                      << (status_.latestSupported ? " (supported)" : " (unsupported)");
+        std::cout << " | " << status_.message << std::endl;
+    }
+
+    mutable std::mutex mutex_;
+    Status status_;
+    bool checkedThisRun_ = false;
+    HMODULE module_ = nullptr;
+    MediusDevice* device_ = nullptr;
+    AbiVersionFn abiVersion_ = nullptr;
+    VersionStringFn versionString_ = nullptr;
+    FindMouseBoxFn findMouseBox_ = nullptr;
+    DeviceFreeFn deviceFree_ = nullptr;
+    MoveRelNowFn moveRelNow_ = nullptr;
+    UsageButtonFn usageButton_ = nullptr;
+    PressFn press_ = nullptr;
+    SoftReleaseFn softRelease_ = nullptr;
+};

--- a/sunone_aimbot_2/mouse/MediusRuntime.h
+++ b/sunone_aimbot_2/mouse/MediusRuntime.h
@@ -7,10 +7,13 @@
 #include <Windows.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -31,6 +34,8 @@ public:
         uint32_t runtimeAbi = 0;
         std::string latestVersion;
         uint32_t latestAbi = 0;
+        std::string selectedPort = "AUTO";
+        uint32_t controlBaud = 4'000'000;
         std::string message;
     };
 
@@ -57,10 +62,70 @@ public:
         return "Any Medius C API release reporting ABI " + supportedAbiLabel();
     }
 
+    static constexpr uint32_t controlBaudRate() noexcept
+    {
+        // Medius upstream currently fixes the control link at 4 Mbaud.
+        return 4'000'000;
+    }
+
+    static constexpr bool customBaudSupported() noexcept
+    {
+        return false;
+    }
+
     Status status() const
     {
         std::lock_guard<std::mutex> lock(mutex_);
         return status_;
+    }
+
+    std::string preferredPort() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return preferredPort_;
+    }
+
+    bool setPreferredPort(const std::string& requested)
+    {
+        const std::string normalized = normalizePort(requested);
+        if (normalized.empty())
+            return false;
+
+        std::lock_guard<std::mutex> lock(mutex_);
+        preferredPort_ = normalized;
+        status_.selectedPort = preferredPort_;
+        saveSettingsUnlocked();
+        status_.message = preferredPort_ == "AUTO"
+            ? "Medius port set to automatic discovery."
+            : "Medius port set to " + preferredPort_ + ".";
+        return true;
+    }
+
+    // Kept as an API for the UI/config layer. The current upstream C API has no baud parameter,
+    // so values other than 4,000,000 are rejected instead of pretending they were applied.
+    bool setControlBaudRate(uint32_t baud)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (baud != controlBaudRate())
+        {
+            status_.message = "Current Medius C API fixes the control baud rate at 4000000.";
+            return false;
+        }
+        status_.controlBaud = controlBaudRate();
+        saveSettingsUnlocked();
+        return true;
+    }
+
+    void requestForceUpdateCheck()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        checkedThisRun_ = false;
+        status_.updateChecked = false;
+        status_.latestKnown = false;
+        status_.latestSupported = false;
+        status_.latestVersion.clear();
+        status_.latestAbi = 0;
+        status_.message = "Medius update check requested; it will run on reconnect.";
     }
 
     bool connectMouse()
@@ -78,16 +143,36 @@ public:
             return false;
         }
 
-        if (!findMouseBox_ || findMouseBox_(&device_) != 0 || !device_)
+        device_ = nullptr;
+        int32_t openStatus = -1;
+        if (preferredPort_ == "AUTO")
+        {
+            if (findMouseBox_)
+                openStatus = findMouseBox_(&device_);
+        }
+        else
+        {
+            if (deviceOpen_)
+                openStatus = deviceOpen_(preferredPort_.c_str(), &device_);
+        }
+
+        if (openStatus != 0 || !device_)
         {
             status_.deviceConnected = false;
-            status_.message = "Medius runtime loaded, but no mouse box was found.";
+            if (preferredPort_ == "AUTO")
+                status_.message = "Medius runtime loaded, but no mouse box was found automatically" + lastErrorSuffixUnlocked() + ".";
+            else
+                status_.message = "Medius runtime loaded, but " + preferredPort_ + " could not be opened" + lastErrorSuffixUnlocked() + ".";
             logStatusUnlocked();
             return false;
         }
 
         status_.deviceConnected = true;
-        status_.message = "Medius connected.";
+        status_.selectedPort = preferredPort_;
+        status_.controlBaud = controlBaudRate();
+        status_.message = preferredPort_ == "AUTO"
+            ? "Medius connected using automatic mouse-box discovery."
+            : "Medius connected on " + preferredPort_ + ".";
         logStatusUnlocked();
         return true;
     }
@@ -130,12 +215,14 @@ private:
 
     using AbiVersionFn = uint32_t (*)();
     using VersionStringFn = const char* (*)();
+    using DeviceOpenFn = int32_t (*)(const char*, MediusDevice**);
     using FindMouseBoxFn = int32_t (*)(MediusDevice**);
     using DeviceFreeFn = void (*)(MediusDevice*);
     using MoveRelNowFn = int32_t (*)(MediusDevice*, int16_t, int16_t);
     using UsageButtonFn = MediusUsage (*)(uint8_t);
     using PressFn = int32_t (*)(MediusDevice*, MediusUsage);
     using SoftReleaseFn = int32_t (*)(MediusDevice*, MediusUsage);
+    using LastErrorMessageFn = uintptr_t (*)(char*, uintptr_t);
 
     struct ReleaseInfo
     {
@@ -144,7 +231,13 @@ private:
         std::string digest;
     };
 
-    MediusRuntime() = default;
+    MediusRuntime()
+    {
+        loadSettingsUnlocked();
+        status_.selectedPort = preferredPort_;
+        status_.controlBaud = controlBaudRate();
+    }
+
     ~MediusRuntime()
     {
         disconnectMouseUnlocked();
@@ -169,6 +262,88 @@ private:
         const DWORD n = GetEnvironmentVariableW(L"LOCALAPPDATA", buffer, static_cast<DWORD>(std::size(buffer)));
         std::filesystem::path base = n ? std::filesystem::path(buffer) : std::filesystem::temp_directory_path();
         return base / L"SunoneAimbot" / L"runtime" / L"medius";
+    }
+
+    static std::filesystem::path settingsPath()
+    {
+        return runtimeDir() / L"settings.ini";
+    }
+
+    static std::string trim(std::string value)
+    {
+        auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+        value.erase(value.begin(), std::find_if(value.begin(), value.end(), notSpace));
+        value.erase(std::find_if(value.rbegin(), value.rend(), notSpace).base(), value.end());
+        return value;
+    }
+
+    static std::string normalizePort(std::string value)
+    {
+        value = trim(std::move(value));
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::toupper(c));
+        });
+
+        if (value == "AUTO")
+            return value;
+
+        const std::string win32Prefix = R"(\\.\)";
+        if (value.rfind(win32Prefix, 0) == 0)
+            value.erase(0, win32Prefix.size());
+
+        if (value.size() <= 3 || value.rfind("COM", 0) != 0)
+            return {};
+
+        const std::string numberText = value.substr(3);
+        if (numberText.empty() || !std::all_of(numberText.begin(), numberText.end(), [](unsigned char c) { return std::isdigit(c) != 0; }))
+            return {};
+
+        try
+        {
+            const unsigned long number = std::stoul(numberText);
+            if (number == 0 || number > 4096)
+                return {};
+            return "COM" + std::to_string(number);
+        }
+        catch (...)
+        {
+            return {};
+        }
+    }
+
+    void loadSettingsUnlocked()
+    {
+        preferredPort_ = "AUTO";
+        std::ifstream in(settingsPath(), std::ios::binary);
+        if (!in)
+            return;
+
+        std::string line;
+        while (std::getline(in, line))
+        {
+            const size_t eq = line.find('=');
+            if (eq == std::string::npos)
+                continue;
+            const std::string key = trim(line.substr(0, eq));
+            const std::string value = trim(line.substr(eq + 1));
+            if (key == "port")
+            {
+                const std::string normalized = normalizePort(value);
+                if (!normalized.empty())
+                    preferredPort_ = normalized;
+            }
+        }
+    }
+
+    void saveSettingsUnlocked() const
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(runtimeDir(), ec);
+        std::ofstream out(settingsPath(), std::ios::binary | std::ios::trunc);
+        if (!out)
+            return;
+        out << "port=" << preferredPort_ << "\n";
+        out << "baud=" << controlBaudRate() << "\n";
     }
 
     static std::wstring quote(const std::filesystem::path& value)
@@ -212,12 +387,14 @@ private:
 
     static std::optional<ReleaseInfo> queryLatest(const std::filesystem::path& dir)
     {
-        std::filesystem::create_directories(dir);
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
         const auto meta = dir / L"latest.json";
         const std::wstring script =
             L"$r=Invoke-RestMethod -Headers @{'User-Agent'='Sunone-Medius'} -Uri 'https://api.github.com/repos/K4HVH/medius/releases/latest'; "
             L"$a=$r.assets | Where-Object {$_.name -eq 'medius-capi-x86_64-pc-windows-msvc.tar.gz'} | Select-Object -First 1; "
             L"if(-not $a){exit 3}; "
+            L"if(-not $a.digest){exit 5}; "
             L"[pscustomobject]@{version=$r.tag_name;url=$a.browser_download_url;digest=$a.digest} | ConvertTo-Json -Compress | Set-Content -Encoding UTF8 " + quote(meta);
         if (!runPowerShell(script))
             return std::nullopt;
@@ -288,6 +465,7 @@ private:
         const auto staging = dir / L"staging";
         std::error_code ec;
         std::filesystem::remove_all(staging, ec);
+        ec.clear();
         std::filesystem::create_directories(staging, ec);
 
         std::wstring digest(latest->digest.begin(), latest->digest.end());
@@ -298,7 +476,7 @@ private:
             L"Invoke-WebRequest -UseBasicParsing -Headers @{'User-Agent'='Sunone-Medius'} -Uri '" + url + L"' -OutFile " + quote(archive) + L"; "
             L"$h=(Get-FileHash -Algorithm SHA256 " + quote(archive) + L").Hash.ToLower(); "
             L"if($h -ne '" + digest + L"'.ToLower()){exit 4}; "
-            L"tar.exe -xzf " + quote(archive) + L" -C " + quote(staging) + L"";
+            L"tar.exe -xzf " + quote(archive) + L" -C " + quote(staging);
         if (!runPowerShell(script))
         {
             status_.message = "Medius release download, SHA-256 verification, or extraction failed.";
@@ -337,14 +515,26 @@ private:
         const auto backup = dir / L"medius_capi.dll.previous";
         unloadUnlocked();
         std::filesystem::remove(backup, ec);
+        ec.clear();
         if (std::filesystem::exists(installed))
+        {
             std::filesystem::rename(installed, backup, ec);
+            if (ec)
+            {
+                status_.message = "Failed to stage the previous Medius DLL for replacement.";
+                return false;
+            }
+        }
+
         ec.clear();
         std::filesystem::copy_file(candidate, installed, std::filesystem::copy_options::overwrite_existing, ec);
         if (ec)
         {
             if (std::filesystem::exists(backup) && !std::filesystem::exists(installed))
+            {
+                ec.clear();
                 std::filesystem::rename(backup, installed, ec);
+            }
             status_.message = "Failed to install the compatible Medius runtime; previous DLL retained.";
             return false;
         }
@@ -354,6 +544,7 @@ private:
         if (!probeDll(installed, verifyAbi, verifyVersion) || !abiSupported(verifyAbi))
         {
             std::filesystem::remove(installed, ec);
+            ec.clear();
             if (std::filesystem::exists(backup))
                 std::filesystem::rename(backup, installed, ec);
             status_.message = "Installed Medius runtime failed verification; rolled back.";
@@ -377,14 +568,17 @@ private:
             return false;
         abiVersion_ = reinterpret_cast<AbiVersionFn>(GetProcAddress(module_, "medius_abi_version"));
         versionString_ = reinterpret_cast<VersionStringFn>(GetProcAddress(module_, "medius_version_string"));
+        deviceOpen_ = reinterpret_cast<DeviceOpenFn>(GetProcAddress(module_, "medius_device_open"));
         findMouseBox_ = reinterpret_cast<FindMouseBoxFn>(GetProcAddress(module_, "medius_device_find_mouse_box"));
         deviceFree_ = reinterpret_cast<DeviceFreeFn>(GetProcAddress(module_, "medius_device_free"));
         moveRelNow_ = reinterpret_cast<MoveRelNowFn>(GetProcAddress(module_, "medius_device_move_rel_now"));
         usageButton_ = reinterpret_cast<UsageButtonFn>(GetProcAddress(module_, "medius_usage_button"));
         press_ = reinterpret_cast<PressFn>(GetProcAddress(module_, "medius_device_press"));
         softRelease_ = reinterpret_cast<SoftReleaseFn>(GetProcAddress(module_, "medius_device_soft_release"));
+        lastErrorMessage_ = reinterpret_cast<LastErrorMessageFn>(GetProcAddress(module_, "medius_last_error_message"));
 
-        if (!abiVersion_ || !versionString_ || !findMouseBox_ || !deviceFree_ || !moveRelNow_ || !usageButton_ || !press_ || !softRelease_)
+        if (!abiVersion_ || !versionString_ || !deviceOpen_ || !findMouseBox_ || !deviceFree_ ||
+            !moveRelNow_ || !usageButton_ || !press_ || !softRelease_)
         {
             unloadUnlocked();
             return false;
@@ -401,7 +595,20 @@ private:
             return false;
         }
         status_.runtimeLoaded = true;
+        status_.selectedPort = preferredPort_;
+        status_.controlBaud = controlBaudRate();
         return true;
+    }
+
+    std::string lastErrorSuffixUnlocked() const
+    {
+        if (!lastErrorMessage_)
+            return {};
+        char buffer[512]{};
+        const uintptr_t n = lastErrorMessage_(buffer, static_cast<uintptr_t>(sizeof(buffer)));
+        if (n == 0 || buffer[0] == '\0')
+            return {};
+        return ": " + std::string(buffer);
     }
 
     void disconnectMouseUnlocked()
@@ -420,38 +627,48 @@ private:
         module_ = nullptr;
         abiVersion_ = nullptr;
         versionString_ = nullptr;
+        deviceOpen_ = nullptr;
         findMouseBox_ = nullptr;
         deviceFree_ = nullptr;
         moveRelNow_ = nullptr;
         usageButton_ = nullptr;
         press_ = nullptr;
         softRelease_ = nullptr;
+        lastErrorMessage_ = nullptr;
         status_.runtimeLoaded = false;
+        status_.runtimeVersion.clear();
+        status_.runtimeAbi = 0;
     }
 
     void logStatusUnlocked() const
     {
-        std::cout << "[Medius] Runtime "
-                  << (status_.runtimeVersion.empty() ? "unknown" : status_.runtimeVersion)
-                  << " / ABI " << status_.runtimeAbi
-                  << " | Supported ABI: " << supportedAbiLabel();
+        std::cout << "[Medius] " << status_.message << '\n';
+        std::cout << "[Medius] Port: " << preferredPort_ << " | baud: " << controlBaudRate() << '\n';
+        if (status_.runtimeLoaded)
+            std::cout << "[Medius] Runtime: v" << status_.runtimeVersion << " / ABI " << status_.runtimeAbi << '\n';
+        std::cout << "[Medius] Supported ABI: " << supportedAbiLabel() << '\n';
         if (status_.latestKnown)
-            std::cout << " | Latest " << status_.latestVersion << " / ABI " << status_.latestAbi
-                      << (status_.latestSupported ? " (supported)" : " (unsupported)");
-        std::cout << " | " << status_.message << std::endl;
+        {
+            std::cout << "[Medius] Latest: v" << status_.latestVersion << " / ABI " << status_.latestAbi
+                      << " / " << (status_.latestSupported ? "supported" : "unsupported") << '\n';
+        }
     }
 
     mutable std::mutex mutex_;
     Status status_;
     bool checkedThisRun_ = false;
+    std::string preferredPort_ = "AUTO";
+
     HMODULE module_ = nullptr;
     MediusDevice* device_ = nullptr;
     AbiVersionFn abiVersion_ = nullptr;
     VersionStringFn versionString_ = nullptr;
+    DeviceOpenFn deviceOpen_ = nullptr;
     FindMouseBoxFn findMouseBox_ = nullptr;
     DeviceFreeFn deviceFree_ = nullptr;
     MoveRelNowFn moveRelNow_ = nullptr;
     UsageButtonFn usageButton_ = nullptr;
     PressFn press_ = nullptr;
     SoftReleaseFn softRelease_ = nullptr;
+    LastErrorMessageFn lastErrorMessage_ = nullptr;
 };

--- a/sunone_aimbot_2/mouse/MouseInput.cpp
+++ b/sunone_aimbot_2/mouse/MouseInput.cpp
@@ -17,6 +17,7 @@
 #include "KmboxAConnection.h"
 #include "KmboxNetConnection.h"
 #include "Makcu.h"
+#include "MediusRuntime.h"
 #include "RP2350.h"
 #include "Teensy41RawHid.h"
 #include "config.h"
@@ -505,6 +506,31 @@ public:
 private:
     std::unique_ptr<MakcuConnection> device_;
 };
+
+class MediusMouseInput final : public IMouseInput
+{
+public:
+    MediusMouseInput()
+        : runtime_(MediusRuntime::instance()), connected_(runtime_.connectMouse())
+    {
+    }
+
+    ~MediusMouseInput() override
+    {
+        if (connected_)
+            runtime_.disconnectMouse();
+    }
+
+    const char* name() const override { return "MEDIUS"; }
+    bool isOpen() const override { return connected_ && runtime_.status().deviceConnected; }
+    bool move(int dx, int dy) override { return connected_ && runtime_.move(dx, dy); }
+    bool leftDown() override { return connected_ && runtime_.leftDown(); }
+    bool leftUp() override { return connected_ && runtime_.leftUp(); }
+
+private:
+    MediusRuntime& runtime_;
+    bool connected_ = false;
+};
 }
 
 std::optional<MouseInputMethod> ParseMouseInputMethod(const std::string& method)
@@ -529,6 +555,8 @@ std::optional<MouseInputMethod> ParseMouseInputMethod(const std::string& method)
         return MouseInputMethod::KmboxA;
     if (method == "MAKCU")
         return MouseInputMethod::Makcu;
+    if (method == "MEDIUS")
+        return MouseInputMethod::Medius;
     return std::nullopt;
 }
 
@@ -545,6 +573,7 @@ std::string MouseInputMethodName(MouseInputMethod method)
     case MouseInputMethod::KmboxNet: return "KMBOX_NET";
     case MouseInputMethod::KmboxA: return "KMBOX_A";
     case MouseInputMethod::Makcu: return "MAKCU";
+    case MouseInputMethod::Medius: return "MEDIUS";
     case MouseInputMethod::Win32:
     default:
         return "WIN32";
@@ -580,6 +609,8 @@ std::unique_ptr<IMouseInput> CreateMouseInputDevice(const Config& config)
         return std::make_unique<KmboxAMouseInput>(config.kmbox_a_pidvid);
     case MouseInputMethod::Makcu:
         return std::make_unique<MakcuMouseInput>(config.makcu_port, static_cast<unsigned int>(config.makcu_baudrate));
+    case MouseInputMethod::Medius:
+        return std::make_unique<MediusMouseInput>();
     case MouseInputMethod::Win32:
     default:
         return std::make_unique<Win32MouseInput>();

--- a/sunone_aimbot_2/mouse/MouseInput.h
+++ b/sunone_aimbot_2/mouse/MouseInput.h
@@ -26,7 +26,8 @@ enum class MouseInputMethod
     Teensy41Hid,
     KmboxNet,
     KmboxA,
-    Makcu
+    Makcu,
+    Medius
 };
 
 std::optional<MouseInputMethod> ParseMouseInputMethod(const std::string& method);

--- a/sunone_aimbot_2/overlay/medius_ui.h
+++ b/sunone_aimbot_2/overlay/medius_ui.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "../config/config.h"
+#include "../imgui/imgui.h"
+#include "../mouse/MediusRuntime.h"
+#include "config_dirty.h"
+
+extern Config config;
+extern std::atomic<bool> input_method_changed;
+
+namespace MediusUI
+{
+inline bool IsActive() noexcept
+{
+    return config.input_method == "MEDIUS";
+}
+
+inline void Select()
+{
+    if (config.input_method == "MEDIUS")
+        return;
+    config.input_method = "MEDIUS";
+    OverlayConfig_MarkDirty();
+    input_method_changed.store(true);
+}
+
+inline void DrawInputSectionExtras()
+{
+    if (!IsActive())
+        return;
+
+    MediusRuntime& runtime = MediusRuntime::instance();
+    const MediusRuntime::Status status = runtime.status();
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Medius");
+
+    static char portBuffer[32] = "AUTO";
+    static std::string loadedPort;
+    static std::string portMessage;
+    const std::string currentPort = runtime.preferredPort();
+    if (loadedPort != currentPort && !ImGui::IsAnyItemActive())
+    {
+        std::snprintf(portBuffer, sizeof(portBuffer), "%s", currentPort.c_str());
+        loadedPort = currentPort;
+    }
+
+    ImGui::TextUnformatted("COM Port");
+    ImGui::SetNextItemWidth(180.0f);
+    ImGui::InputText("##medius_port", portBuffer, sizeof(portBuffer));
+    ImGui::SameLine();
+    if (ImGui::Button("Apply##medius_port"))
+    {
+        if (runtime.setPreferredPort(portBuffer))
+        {
+            loadedPort = runtime.preferredPort();
+            std::snprintf(portBuffer, sizeof(portBuffer), "%s", loadedPort.c_str());
+            portMessage = "Port saved. Reconnecting Medius...";
+            input_method_changed.store(true);
+        }
+        else
+        {
+            portMessage = "Invalid port. Use AUTO or COM1..COM4096.";
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Auto##medius_port"))
+    {
+        runtime.setPreferredPort("AUTO");
+        loadedPort = "AUTO";
+        std::snprintf(portBuffer, sizeof(portBuffer), "%s", "AUTO");
+        portMessage = "Automatic mouse-box discovery enabled.";
+        input_method_changed.store(true);
+    }
+
+    if (!portMessage.empty())
+        ImGui::TextDisabled("%s", portMessage.c_str());
+
+    int baud = static_cast<int>(MediusRuntime::controlBaudRate());
+    ImGui::TextUnformatted("Baud Rate");
+    ImGui::SetNextItemWidth(180.0f);
+    ImGui::BeginDisabled();
+    ImGui::InputInt("##medius_baud", &baud, 0, 0);
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    ImGui::TextDisabled("fixed by Medius C API");
+    ImGui::TextDisabled("Current upstream control transport uses 4,000,000 baud; the C ABI has no custom baud parameter.");
+
+    ImGui::Separator();
+    if (status.deviceConnected)
+        ImGui::TextColored(ImVec4(0.35f, 0.90f, 0.45f, 1.0f), "Device: Connected");
+    else
+        ImGui::TextColored(ImVec4(1.0f, 0.42f, 0.42f, 1.0f), "Device: Not connected");
+
+    ImGui::Text("Selected port: %s", currentPort.c_str());
+    ImGui::Text("Control baud: %u", MediusRuntime::controlBaudRate());
+
+    if (status.runtimeLoaded)
+        ImGui::Text("Runtime: v%s / ABI %u", status.runtimeVersion.c_str(), status.runtimeAbi);
+    else
+        ImGui::TextDisabled("Runtime: not loaded yet");
+
+    const std::string supported = MediusRuntime::supportedAbiLabel();
+    ImGui::Text("Supported ABI: %s", supported.c_str());
+
+    if (status.latestKnown)
+    {
+        if (status.latestSupported)
+        {
+            ImGui::TextColored(
+                ImVec4(0.35f, 0.90f, 0.45f, 1.0f),
+                "Latest: v%s / ABI %u - supported",
+                status.latestVersion.c_str(),
+                status.latestAbi);
+        }
+        else
+        {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.55f, 0.25f, 1.0f),
+                "Latest: v%s / ABI %u - NOT supported",
+                status.latestVersion.c_str(),
+                status.latestAbi);
+        }
+    }
+    else if (status.updateChecked)
+    {
+        ImGui::TextDisabled("Latest release: check failed or ABI could not be probed");
+    }
+    else
+    {
+        ImGui::TextDisabled("Latest release: will be checked automatically when Medius connects");
+    }
+
+    ImGui::TextDisabled("Auto update: enabled (SHA-256 verification + ABI gate + rollback)");
+    if (ImGui::Button("Check updates & reconnect##medius_update"))
+    {
+        runtime.requestForceUpdateCheck();
+        input_method_changed.store(true);
+    }
+
+    const MediusRuntime::Status refreshed = runtime.status();
+    if (!refreshed.message.empty())
+        ImGui::TextWrapped("%s", refreshed.message.c_str());
+}
+}

--- a/sunone_aimbot_2/overlay/ui_sections.h
+++ b/sunone_aimbot_2/overlay/ui_sections.h
@@ -4,8 +4,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstring>
 
 #include "imgui/imgui.h"
+#include "medius_ui.h"
 
 namespace OverlayUI
 {
@@ -15,6 +17,12 @@ struct SettingRow
     ImVec2 max;
     float controlWidth;
 };
+
+inline bool& IsMediusInputSection() noexcept
+{
+    static thread_local bool value = false;
+    return value;
+}
 
 inline float AdaptiveItemWidth(float ratio = 0.64f) noexcept
 {
@@ -80,6 +88,7 @@ inline SettingRow BeginSettingRow(const char* label, float height = 58.0f, float
     ImGui::SetCursorScreenPos(ImVec2(rowMax.x - controlW - 15.0f, controlY));
     ImGui::SetNextItemWidth(controlW);
 
+    IM_UNUSED(style);
     return { rowMin, rowMax, controlW };
 }
 
@@ -142,6 +151,51 @@ inline bool ButtonRow(const char* label, const char* buttonText, const char* id 
 
 inline bool ComboRow(const char* label, int* currentItem, const char* const items[], int itemsCount, const char* id = "##value") noexcept
 {
+    // draw_mouse.cpp owns the existing backend list. Inject MEDIUS here without changing its
+    // indexing contract: selecting MEDIUS writes the method directly and returns false, while
+    // selecting any existing backend returns the legacy index to the caller.
+    if (label && std::strcmp(label, "Mouse Input Method") == 0)
+    {
+        const SettingRow row = BeginSettingRow(label);
+        const bool mediusActive = MediusUI::IsActive();
+        const char* preview = "";
+        if (mediusActive)
+            preview = "MEDIUS";
+        else if (*currentItem >= 0 && *currentItem < itemsCount)
+            preview = items[*currentItem];
+
+        bool existingChanged = false;
+        int newExistingIndex = *currentItem;
+        if (ImGui::BeginCombo(id, preview))
+        {
+            for (int i = 0; i < itemsCount; ++i)
+            {
+                const bool selected = !mediusActive && i == *currentItem;
+                if (ImGui::Selectable(items[i], selected))
+                {
+                    newExistingIndex = i;
+                    existingChanged = true;
+                }
+                if (selected)
+                    ImGui::SetItemDefaultFocus();
+            }
+
+            if (ImGui::Selectable("MEDIUS", mediusActive))
+                MediusUI::Select();
+            if (mediusActive)
+                ImGui::SetItemDefaultFocus();
+            ImGui::EndCombo();
+        }
+        EndSettingRow(row);
+
+        if (existingChanged)
+        {
+            *currentItem = newExistingIndex;
+            return true;
+        }
+        return false;
+    }
+
     const SettingRow row = BeginSettingRow(label);
     const bool changed = ImGui::Combo(id, currentItem, items, itemsCount);
     EndSettingRow(row);
@@ -218,12 +272,18 @@ inline bool BeginSection(const char* label, const char* id = nullptr, bool defau
     IM_UNUSED(defaultOpen);
     IM_UNUSED(label);
 
+    IsMediusInputSection() = (id && std::strcmp(id, "mouse_section_input_method") == 0);
     BeginBodyGroup(false);
     return true;
 }
 
 inline void EndSection() noexcept
 {
+    if (IsMediusInputSection())
+    {
+        MediusUI::DrawInputSectionExtras();
+        IsMediusInputSection() = false;
+    }
     EndBodyGroup(false);
     ImGui::PopID();
     ImGui::Dummy(ImVec2(0.0f, 7.0f));

--- a/tests/medius_runtime_smoke.cpp
+++ b/tests/medius_runtime_smoke.cpp
@@ -1,0 +1,9 @@
+#include "sunone_aimbot_2/mouse/MediusRuntime.h"
+#include <iostream>
+
+int main()
+{
+    std::cout << "Supported ABI: " << MediusRuntime::supportedAbiLabel() << '\n';
+    std::cout << "Supported versions: " << MediusRuntime::supportedVersionLabel() << '\n';
+    return MediusRuntime::supportedAbiLabel().empty() ? 1 : 0;
+}

--- a/tests/medius_runtime_smoke.cpp
+++ b/tests/medius_runtime_smoke.cpp
@@ -1,8 +1,9 @@
 #include "sunone_aimbot_2/mouse/MediusRuntime.h"
 
 #include <iostream>
+#include <string>
 
-int main()
+int main(int argc, char** argv)
 {
     if (MediusRuntime::supportedAbiLabel() != "6")
         return 1;
@@ -29,5 +30,27 @@ int main()
     std::cout << "Supported versions: " << MediusRuntime::supportedVersionLabel() << '\n';
     std::cout << "Control baud: " << MediusRuntime::controlBaudRate() << '\n';
     std::cout << "Port policy: PASS\n";
+
+    if (argc > 1 && std::string(argv[1]) == "--update-integration")
+    {
+        runtime.requestForceUpdateCheck();
+        (void)runtime.connectMouse(); // A hosted runner normally has no Medius box; update/probe must still work.
+        const auto status = runtime.status();
+        if (!status.updateChecked)
+            return 20;
+        if (!status.latestKnown)
+            return 21;
+        if (status.latestSupported && !status.runtimeLoaded)
+            return 22;
+        if (status.latestSupported && status.runtimeAbi != status.latestAbi)
+            return 23;
+
+        std::cout << "Latest: v" << status.latestVersion << " / ABI " << status.latestAbi
+                  << " / " << (status.latestSupported ? "supported" : "unsupported") << '\n';
+        std::cout << "Runtime loaded: " << (status.runtimeLoaded ? "yes" : "no") << '\n';
+        std::cout << "Updater integration: PASS\n";
+        runtime.disconnectMouse();
+    }
+
     return 0;
 }

--- a/tests/medius_runtime_smoke.cpp
+++ b/tests/medius_runtime_smoke.cpp
@@ -1,9 +1,33 @@
 #include "sunone_aimbot_2/mouse/MediusRuntime.h"
+
 #include <iostream>
 
 int main()
 {
+    if (MediusRuntime::supportedAbiLabel() != "6")
+        return 1;
+    if (MediusRuntime::controlBaudRate() != 4000000u)
+        return 2;
+    if (MediusRuntime::customBaudSupported())
+        return 3;
+
+    MediusRuntime& runtime = MediusRuntime::instance();
+    if (!runtime.setPreferredPort("COM7") || runtime.preferredPort() != "COM7")
+        return 4;
+    if (!runtime.setPreferredPort("\\\\.\\COM12") || runtime.preferredPort() != "COM12")
+        return 5;
+    if (runtime.setPreferredPort("INVALID"))
+        return 6;
+    if (runtime.setControlBaudRate(115200u))
+        return 7;
+    if (!runtime.setControlBaudRate(4000000u))
+        return 8;
+    if (!runtime.setPreferredPort("AUTO") || runtime.preferredPort() != "AUTO")
+        return 9;
+
     std::cout << "Supported ABI: " << MediusRuntime::supportedAbiLabel() << '\n';
     std::cout << "Supported versions: " << MediusRuntime::supportedVersionLabel() << '\n';
-    return MediusRuntime::supportedAbiLabel().empty() ? 1 : 0;
+    std::cout << "Control baud: " << MediusRuntime::controlBaudRate() << '\n';
+    std::cout << "Port policy: PASS\n";
+    return 0;
 }

--- a/tests/medius_ui_smoke.cpp
+++ b/tests/medius_ui_smoke.cpp
@@ -1,0 +1,9 @@
+#include "sunone_aimbot_2/overlay/ui_sections.h"
+
+static_assert(MediusRuntime::controlBaudRate() == 4000000u, "Medius control baud changed unexpectedly");
+static_assert(!MediusRuntime::customBaudSupported(), "Update the UI when Medius gains custom baud support");
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
## Summary

This pull request adds Medius as a first-class mouse input backend for Sunone, including UI integration, runtime management, ABI compatibility checks, COM-port selection, and automatic updates for the Medius C API runtime.

The implementation is designed to avoid bundling a fixed Medius DLL with the application. Instead, Sunone dynamically manages the Medius C API runtime, validates compatibility before activation, and preserves the previously working runtime if a newer release is incompatible.

## What this PR adds

### 1. Medius mouse input backend

Adds `MEDIUS` to the existing mouse input abstraction and factory.

The new backend:

- creates a Medius device through the runtime wrapper
- supports relative mouse movement
- supports left-button press and release
- uses `medius_device_soft_release()` for release semantics so injected state can be cleared without forcing a physical button-up state
- integrates with the existing `IMouseInput` interface and input-method switching path

The backend is wired into:

- `MouseInputMethod`
- input-method parsing
- input-method display names
- `CreateMouseInputDevice()`

### 2. UI integration

Adds Medius to the existing Input Method UI rather than introducing a separate settings page.

The Medius UI exposes:

- Medius as a selectable mouse input method
- device connection state
- selected COM port
- control baud rate
- installed runtime version
- installed runtime ABI
- supported Sunone ABI list
- latest upstream Medius version
- latest upstream ABI
- whether the latest release is compatible
- manual `Check updates & reconnect` functionality

Changing Medius connection settings triggers the existing input-method rebuild mechanism so the backend is recreated with the new configuration.

### 3. COM-port selection

Medius supports two connection modes in this integration:

- `AUTO` -> uses `medius_device_find_mouse_box()`
- explicit `COMx` -> uses `medius_device_open()` on the selected port

The UI allows selecting `AUTO` or an explicit COM port.

This is a real backend setting, not a cosmetic UI option: the selected value changes which Medius C API function is used to open the device.

### 4. Baud-rate handling

The current Medius Windows transport uses a fixed 4,000,000 baud control connection and the public C API does not expose a baud-rate parameter in `medius_device_open()`.

For that reason, the UI reports the effective control baud rate as:

`4,000,000`

but does not pretend that arbitrary baud rates are supported by the current Medius ABI.

This keeps the UI behavior aligned with the actual Medius API and leaves room to expose configurable baud rates later if the upstream C API adds that capability.

### 5. Dynamic runtime loading

The Medius C API is loaded dynamically at runtime instead of linking against a fixed import library.

This removes the need to ship a specific Medius import library with the Sunone build and allows runtime compatibility to be checked before the DLL is activated.

Required C API exports are resolved dynamically before use.

### 6. ABI-based compatibility policy

Sunone currently accepts Medius C API ABI:

`6`

Compatibility is determined by the runtime itself through `medius_abi_version()` rather than by relying only on semantic version numbers.

This means a release is considered compatible if its reported ABI is supported by Sunone.

The UI reports:

- installed runtime version and ABI
- supported ABI values
- latest release version and ABI
- whether the latest release is supported

Example:

```text
Runtime: v3.3.1 / ABI 6
Supported ABI: 6
Latest: v3.3.1 / ABI 6 / supported
```

If a future release reports an unsupported ABI, for example ABI 7, Sunone will not replace the currently working ABI 6 runtime.

### 7. Automatic Medius runtime updates

The runtime updater performs the following sequence:

1. queries the latest `K4HVH/medius` GitHub release
2. locates the Windows x64 C API archive
3. downloads the release archive into staging
4. validates the published SHA-256 digest
5. extracts the archive
6. loads the candidate DLL from staging
7. calls `medius_abi_version()` and `medius_version_string()`
8. verifies that the candidate ABI is supported by Sunone
9. backs up the currently installed runtime
10. atomically replaces the runtime only after validation succeeds

If the candidate is incompatible or validation fails:

- the existing runtime is kept
- the incompatible DLL is not activated
- the UI/status output reports that the latest release is unsupported or failed validation

The previous runtime is preserved as a backup for rollback.

### 8. Runtime location

The Medius runtime is stored outside the repository/build output under the user's local application data runtime directory.

This avoids modifying source-controlled files and keeps Medius runtime updates independent from Sunone application updates.

### 9. Manual update and reconnect

The Medius UI provides a manual update/reconnect action.

This forces a fresh release check and then rebuilds the Medius input backend so the selected port and newly installed compatible runtime can be used immediately.

## Current upstream compatibility

At the time this PR was prepared, the latest Medius release is:

- Medius: `v3.3.1`
- C API ABI: `6`

This matches the ABI currently supported by this integration.

## Testing

A Windows GitHub Actions smoke workflow was added for the Medius integration.

The following checks have been exercised successfully on a Windows runner:

- MSVC C++17 compile of the Medius runtime wrapper
- runtime policy test
- supported ABI check
- COM-port policy check
- fixed control-baud policy check
- Medius UI integration compile
- live updater integration test against the current Medius GitHub release
- download of the latest Medius C API archive
- SHA-256 validation
- archive extraction
- candidate DLL loading
- ABI query
- version query
- compatibility decision

The updater integration test successfully reported:

```text
Supported ABI: 6
Supported versions: Any Medius C API release reporting ABI 6
Control baud: 4000000
Port policy: PASS
Runtime: v3.3.1 / ABI 6
Supported ABI: 6
Latest: v3.3.1 / ABI 6 / supported
Runtime loaded: yes
Updater integration: PASS
```

No Medius hardware is attached to the GitHub-hosted Windows runner, so the CI environment cannot validate physical cursor movement or physical device I/O. Hardware connection behavior therefore still requires a real Medius device for final end-to-end validation.

## Notes about backend compile testing

A standalone compile attempt for the full `MouseInput.cpp` translation unit is affected by unrelated upstream serial-vendor include availability in the repository layout used by CI.

Because of that unrelated dependency, the Medius-specific CI checks validate the backend wiring contract separately while the Medius runtime and UI code are compiled directly with MSVC.

The Medius runtime itself, UI integration, updater flow, ABI compatibility logic, and current Medius DLL loading path have all been exercised successfully on Windows CI.

## Files added / modified

Main areas touched by this PR include:

- Medius runtime wrapper
- mouse input enum / parser / factory
- input-method UI integration
- Medius UI helper
- Medius smoke tests
- Windows GitHub Actions smoke workflow

## Design goals

The implementation intentionally follows these principles:

- no hard dependency on a specific Medius semantic version
- ABI compatibility is authoritative
- never replace a working runtime with an incompatible one
- verify downloaded runtime artifacts before activation
- keep hardware configuration visible in the existing input-method UI
- avoid presenting unsupported baud-rate controls as if they were functional
- allow future Medius ABI versions to be supported by extending the supported ABI list

## References

- Medius project: https://github.com/K4HVH/medius
- Medius C bindings documentation: https://medius.k4tech.net/bindings/c
